### PR TITLE
Add Dependabot config for weekly Docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
### Motivation
- Add `dependabot` configuration to automate Docker dependency updates on a weekly schedule and standardize update PRs.

### Description
- Create `/.github/dependabot.yml` configuring `package-ecosystem: "docker"`, `directory: "/"`, a weekly schedule at `monday 06:00 UTC`, `open-pull-requests-limit: 5`, and commit message settings with `prefix: "chore"` and `include: "scope"`.

### Testing
- No automated tests were added or executed for this configuration change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9915f69908328b03e6a810443fbd6)