### PR TITLE
Add Dependabot Docker updates and bump Papra to 26.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/papra/build.yaml
+++ b/papra/build.yaml
@@ -1,7 +1,7 @@
 build_from:
-  amd64: ghcr.io/papra-hq/papra:26.0.0
-  aarch64: ghcr.io/papra-hq/papra:26.0.0
-  armv7: ghcr.io/papra-hq/papra:26.0.0
+  amd64: ghcr.io/papra-hq/papra:26.3.0
+  aarch64: ghcr.io/papra-hq/papra:26.3.0
+  armv7: ghcr.io/papra-hq/papra:26.3.0
 labels:
   org.opencontainers.image.title: "Papra"
   org.opencontainers.image.description: "Minimal document management platform"

--- a/papra/config.yaml
+++ b/papra/config.yaml
@@ -1,5 +1,5 @@
 name: Papra
-version: "26.0.0"
+version: "26.3.0"
 slug: papra
 description: Minimal document management platform – self-hosted with a clean UI.
 url: https://github.com/chWagnr/hassio-addons/tree/main/papra


### PR DESCRIPTION
### Motivation
- Keep the Docker base image for the Papra add-on up to date and enable automated dependency updates.
- Ensure the add-on metadata version matches the updated base image to avoid mismatch between build and config.

### Description
- Add a Dependabot config at `/.github/dependabot.yml` to enable weekly Docker image update PRs with a limit of `5` open PRs and commit message prefix `chore`.
- Bump the Papra build base images in `papra/build.yaml` from `ghcr.io/papra-hq/papra:26.0.0` to `ghcr.io/papra-hq/papra:26.3.0` for `amd64`, `aarch64`, and `armv7`.
- Update the add-on metadata version in `papra/config.yaml` from `"26.0.0"` to `"26.3.0"` to match the image bump.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9915f69908328b03e6a810443fbd6)