### PR TITLE
Bump Papra to 26.3.0-rootless and add Dependabot Docker updates

### DIFF
--- a/papra/build.yaml
+++ b/papra/build.yaml
@@ -1,7 +1,7 @@
 build_from:
-  amd64: ghcr.io/papra-hq/papra:26.3.0
-  aarch64: ghcr.io/papra-hq/papra:26.3.0
-  armv7: ghcr.io/papra-hq/papra:26.3.0
+  amd64: ghcr.io/papra-hq/papra:26.3.0-rootless
+  aarch64: ghcr.io/papra-hq/papra:26.3.0-rootless
+  armv7: ghcr.io/papra-hq/papra:26.3.0-rootless
 labels:
   org.opencontainers.image.title: "Papra"
   org.opencontainers.image.description: "Minimal document management platform"


### PR DESCRIPTION
### Motivation
- Update the Papra addon to use the rootless `26.3.0` base images to pick up newer fixes and improvements.
- Add Dependabot configuration to keep Docker images up-to-date on a weekly schedule.

### Description
- Add `/.github/dependabot.yml` to enable Dependabot for the `docker` ecosystem with a weekly schedule (Monday 06:00 UTC), an open PR limit of 5, and commit messages prefixed with `chore`.
- Update `papra/build.yaml` `build_from` entries to `ghcr.io/papra-hq/papra:26.3.0-rootless` for `amd64`, `aarch64`, and `armv7`.
- Bump the `version` field in `papra/config.yaml` to `26.3.0` to match the updated base image.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9915f69908328b03e6a810443fbd6)