### PR TITLE
Remove bashio installation from Dockerfile

### DIFF
--- a/papra/Dockerfile
+++ b/papra/Dockerfile
@@ -2,13 +2,6 @@ ARG BUILD_FROM
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
-# Install bashio for reading Home Assistant addon options
-ARG BASHIO_VERSION="v0.16.2"
-RUN apk add --no-cache curl jq \
-    && curl -fsSL "https://github.com/hassio-addons/bashio/archive/${BASHIO_VERSION}.tar.gz" \
-       | tar xzf - --strip-components=1 -C /usr/local/lib bashio-${BASHIO_VERSION#v}/lib \
-    && ln -s /usr/local/lib/bashio/bashio /usr/local/bin/bashio
-
 # Copy run script
 COPY run.sh /run.sh
 RUN chmod a+x /run.sh


### PR DESCRIPTION
### Motivation
- Remove an unused runtime dependency and network fetch during image build by eliminating the `bashio` installation and related tools to simplify the Dockerfile.

### Description
- Removed `ARG BASHIO_VERSION`, the `apk add curl jq` step, and the `curl`/`tar` commands that downloaded and symlinked `bashio`, leaving only the `COPY run.sh`, `chmod`, and `CMD` steps.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9994a21d88328a26319477fbbebb5)